### PR TITLE
WIP: Support for context function with recursive type parameters

### DIFF
--- a/arrow-inject-annotations/src/main/kotlin/arrow/inject/annotations/Resolve.kt
+++ b/arrow-inject-annotations/src/main/kotlin/arrow/inject/annotations/Resolve.kt
@@ -8,4 +8,16 @@ package arrow.inject.annotations
 annotation class Resolve
 
 @CompileTime
-fun <A> context() = Unit
+fun <A> context(a: A? = null) = Unit
+
+@CompileTime
+fun <A, B> context(a: A? = null, b: B? = null) = Unit
+
+@CompileTime
+fun <A, B, C> context(a: A? = null, b: B? = null, c: C? = null) = Unit
+
+@CompileTime
+fun <A, B, C, D> context(a: A? = null, b: B? = null, c: C? = null, d: D? = null) = Unit
+
+@CompileTime
+fun <A, B, C, D, E> context(a: A? = null, b: B? = null, c: C? = null, d: D? = null, e: E? = null) = Unit

--- a/arrow-inject-compiler-plugin/src/main/kotlin/arrow/inject/compiler/plugin/fir/resolution/checkers/call/FirAbstractCallChecker.kt
+++ b/arrow-inject-compiler-plugin/src/main/kotlin/arrow/inject/compiler/plugin/fir/resolution/checkers/call/FirAbstractCallChecker.kt
@@ -49,10 +49,11 @@ internal interface FirAbstractCallChecker : FirAbstractProofComponent, FirResolu
     }
   }
   fun FirQualifiedAccess.contextReceiversResolutionMap(): Map<ProofResolution?, FirElement> {
-    val targetType = typeArguments.firstOrNull()?.toConeTypeProjection()?.type
-    return if (targetType != null) {
-      val contextProofResolution = resolveProof(ProviderAnnotation, targetType, mutableListOf())
-      mapOf(contextProofResolution to this)
+    val targetTypes = typeArguments.map { it.toConeTypeProjection().type }
+    return if (targetTypes.isNotEmpty()) {
+      targetTypes.fold(mutableMapOf()) { map, type -> map.also {
+        if(type != null) it[resolveProof(ProviderAnnotation, type, mutableListOf())] = this
+      }}
     } else emptyMap()
   }
 

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.fir.ir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.fir.ir.txt
@@ -60,6 +60,33 @@ FILE fqName:foo.bar fileName:/context_receivers.kt
     BLOCK_BODY
       CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
         message: CONST String type=kotlin.String value="will drop from nested body"
+      RETURN type=kotlin.Nothing from='public final fun f2 (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+  FUN name:workaround visibility:public modality:FINAL <> () returnType:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
+        message: CONST String type=kotlin.String value="will drop from nested body"
+      RETURN type=kotlin.Nothing from='public final fun workaround (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.workaround'
+                  CALL 'public final fun <get-x> (): kotlin.Int declared in foo.bar.Repo' type=kotlin.Int origin=GET_PROPERTY
+                    $this: CONSTRUCTOR_CALL 'public constructor <init> (_context_receiver_0: foo.bar.Persistence, x: kotlin.Int) [primary] declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+                      _context_receiver_0: GET_VAR '$this$contextual: foo.bar.Persistence declared in foo.bar.workaround.<anonymous>' type=foo.bar.Persistence origin=null
+                      x: CONST Int type=kotlin.Int value=0
   FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
     BLOCK_BODY
       VAR name:result type:kotlin.Int [val]

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.fir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.fir.txt
@@ -22,6 +22,13 @@ FILE: context_receivers.kt
         R|arrow/inject/annotations/context|<R|foo/bar/Persistence|>()
         ^f2 R|foo/bar/Repo.Repo|(Int(0)).R|foo/bar/Repo.x|
     }
+    public final fun workaround(): R|kotlin/Int| {
+        R|kotlin/io/println|(String(will drop from nested body))
+        ^workaround R|arrow/inject/annotations/contextual|<R|foo/bar/Persistence|, R|kotlin/Int|>(R|foo/bar/Persistence.Persistence|(), <L> = contextual@fun R|foo/bar/Persistence|.<anonymous>(): R|kotlin/Int| <inline=Inline, kind=UNKNOWN>  {
+            ^ R|foo/bar/Repo.Repo|(Int(0)).R|foo/bar/Repo.x|
+        }
+        )
+    }
     public final fun box(): R|kotlin/String| {
         lval result: R|kotlin/Int| = R|foo/bar/f2|()
         ^box when () {

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.kt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers.kt
@@ -16,6 +16,13 @@ fun f2(): Int {
   return Repo(0).x
 }
 
+fun workaround(): Int {
+  println("will drop from nested body")
+  return contextual<Persistence, Int>(Persistence()) {
+    Repo(0).x
+  }
+}
+
 fun box(): String {
   val result = f2()
   return if (result == 0) {

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.fir.ir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.fir.ir.txt
@@ -1,0 +1,301 @@
+FILE fqName:foo.bar fileName:/context_receivers_with_more_than_two_type_parameters.kt
+  CLASS CLASS name:Persistence modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Persistence
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.Persistence [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Persistence modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:X modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.X
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.X [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:X modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:Y modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Y
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.Y [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Y modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:Z modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Z
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.Z [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Z modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:W modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.W
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.W [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:W modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:Repo modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Repo
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField0 type:foo.bar.Persistence visibility:private [final]
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField1 type:foo.bar.X visibility:private [final]
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField2 type:foo.bar.Y visibility:private [final]
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField3 type:foo.bar.Z visibility:private [final]
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField4 type:foo.bar.W visibility:private [final]
+    CONSTRUCTOR visibility:public <> (_context_receiver_0:foo.bar.Persistence, _context_receiver_1:foo.bar.X, _context_receiver_2:foo.bar.Y, _context_receiver_3:foo.bar.Z, _context_receiver_4:foo.bar.W, x:kotlin.Int) returnType:foo.bar.Repo [primary]
+      VALUE_PARAMETER name:_context_receiver_0 index:0 type:foo.bar.Persistence
+      VALUE_PARAMETER name:_context_receiver_1 index:1 type:foo.bar.X
+      VALUE_PARAMETER name:_context_receiver_2 index:2 type:foo.bar.Y
+      VALUE_PARAMETER name:_context_receiver_3 index:3 type:foo.bar.Z
+      VALUE_PARAMETER name:_context_receiver_4 index:4 type:foo.bar.W
+      VALUE_PARAMETER name:x index:5 type:kotlin.Int
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField0 type:foo.bar.Persistence visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_0: foo.bar.Persistence declared in foo.bar.Repo.<init>' type=foo.bar.Persistence origin=null
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField1 type:foo.bar.X visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_1: foo.bar.X declared in foo.bar.Repo.<init>' type=foo.bar.X origin=null
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField2 type:foo.bar.Y visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_2: foo.bar.Y declared in foo.bar.Repo.<init>' type=foo.bar.Y origin=null
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField3 type:foo.bar.Z visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_3: foo.bar.Z declared in foo.bar.Repo.<init>' type=foo.bar.Z origin=null
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField4 type:foo.bar.W visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_4: foo.bar.W declared in foo.bar.Repo.<init>' type=foo.bar.W origin=null
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Repo modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:x visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'x: kotlin.Int declared in foo.bar.Repo.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-x> visibility:public modality:FINAL <> ($this:foo.bar.Repo) returnType:kotlin.Int
+        correspondingProperty: PROPERTY name:x visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:foo.bar.Repo
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-x> (): kotlin.Int declared in foo.bar.Repo'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo.<get-x>' type=foo.bar.Repo origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:f visibility:public modality:FINAL <> () returnType:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
+        message: CONST String type=kotlin.String value="123"
+      RETURN type=kotlin.Nothing from='public final fun f (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f'
+                  CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+                    <T>: foo.bar.X
+                    <R>: kotlin.Int
+                    ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.X' type=foo.bar.X origin=null
+                    f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.X, kotlin.Int> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.X) returnType:kotlin.Int
+                        $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.X
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f.<anonymous>'
+                            CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+                              <T>: foo.bar.Y
+                              <R>: kotlin.Int
+                              ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Y' type=foo.bar.Y origin=null
+                              f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Y, kotlin.Int> origin=LAMBDA
+                                FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Y) returnType:kotlin.Int
+                                  $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Y
+                                  BLOCK_BODY
+                                    RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f.<anonymous>.<anonymous>'
+                                      CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+                                        <T>: foo.bar.Z
+                                        <R>: kotlin.Int
+                                        ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Z' type=foo.bar.Z origin=null
+                                        f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Z, kotlin.Int> origin=LAMBDA
+                                          FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Z) returnType:kotlin.Int
+                                            $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Z
+                                            BLOCK_BODY
+                                              RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f.<anonymous>.<anonymous>.<anonymous>'
+                                                CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+                                                  <T>: foo.bar.W
+                                                  <R>: kotlin.Int
+                                                  ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.W' type=foo.bar.W origin=null
+                                                  f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.W, kotlin.Int> origin=LAMBDA
+                                                    FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.W) returnType:kotlin.Int
+                                                      $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.W
+                                                      BLOCK_BODY
+                                                        RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f.<anonymous>.<anonymous>.<anonymous>.<anonymous>'
+                                                          CALL 'public final fun <get-x> (): kotlin.Int declared in foo.bar.Repo' type=kotlin.Int origin=GET_PROPERTY
+                                                            $this: CONSTRUCTOR_CALL 'public constructor <init> (_context_receiver_0: foo.bar.Persistence, _context_receiver_1: foo.bar.X, _context_receiver_2: foo.bar.Y, _context_receiver_3: foo.bar.Z, _context_receiver_4: foo.bar.W, x: kotlin.Int) [primary] declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+                                                              _context_receiver_0: GET_VAR '$this$contextual: foo.bar.Persistence declared in foo.bar.f.<anonymous>' type=foo.bar.Persistence origin=null
+                                                              _context_receiver_1: GET_VAR '$this$contextual: foo.bar.X declared in foo.bar.f.<anonymous>.<anonymous>' type=foo.bar.X origin=null
+                                                              _context_receiver_2: GET_VAR '$this$contextual: foo.bar.Y declared in foo.bar.f.<anonymous>.<anonymous>.<anonymous>' type=foo.bar.Y origin=null
+                                                              _context_receiver_3: GET_VAR '$this$contextual: foo.bar.Z declared in foo.bar.f.<anonymous>.<anonymous>.<anonymous>.<anonymous>' type=foo.bar.Z origin=null
+                                                              _context_receiver_4: GET_VAR '$this$contextual: foo.bar.W declared in foo.bar.f.<anonymous>.<anonymous>.<anonymous>.<anonymous>.<anonymous>' type=foo.bar.W origin=null
+                                                              x: CONST Int type=kotlin.Int value=0
+  FUN name:f2 visibility:public modality:FINAL <> () returnType:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
+        message: CONST String type=kotlin.String value="will drop from nested body"
+      RETURN type=kotlin.Nothing from='public final fun f2 (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f2'
+                  CONST Int type=kotlin.Int value=2
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.Int [val]
+        CALL 'public final fun f (): kotlin.Int declared in foo.bar' type=kotlin.Int origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in foo.bar'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: GET_VAR 'val result: kotlin.Int [val] declared in foo.bar.box' type=kotlin.Int origin=null
+              arg1: CONST Int type=kotlin.Int value=0
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="Fail: "
+              GET_VAR 'val result: kotlin.Int [val] declared in foo.bar.box' type=kotlin.Int origin=null
+FILE fqName:foo.bar.annotations fileName:/Annotations.kt
+  CLASS ANNOTATION_CLASS name:Given modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+    annotations:
+      Context
+      Retention(value = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RUNTIME' type=kotlin.annotation.AnnotationRetention)
+      Target(allowedTargets = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:CLASS' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FUNCTION' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:PROPERTY' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:VALUE_PARAMETER' type=kotlin.annotation.AnnotationTarget])
+      MustBeDocumented
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.annotations.Given
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.annotations.Given [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:Given modality:OPEN visibility:public superTypes:[kotlin.Annotation]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS ANNOTATION_CLASS name:Config modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+    annotations:
+      Context
+      Retention(value = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RUNTIME' type=kotlin.annotation.AnnotationRetention)
+      Target(allowedTargets = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:CLASS' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FUNCTION' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:PROPERTY' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:VALUE_PARAMETER' type=kotlin.annotation.AnnotationTarget])
+      MustBeDocumented
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.annotations.Config
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.annotations.Config [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:Config modality:OPEN visibility:public superTypes:[kotlin.Annotation]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+FILE fqName:foo.bar.identity fileName:/Identity.kt

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.fir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.fir.txt
@@ -1,0 +1,67 @@
+FILE: context_receivers_with_more_than_two_type_parameters.kt
+    package foo.bar
+
+    @R|arrow/inject/annotations/Provider|() public final class Persistence : R|kotlin/Any| {
+        public constructor(): R|foo/bar/Persistence| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|arrow/inject/annotations/Provider|() public final class X : R|kotlin/Any| {
+        public constructor(): R|foo/bar/X| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|arrow/inject/annotations/Provider|() public final class Y : R|kotlin/Any| {
+        public constructor(): R|foo/bar/Y| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|arrow/inject/annotations/Provider|() public final class Z : R|kotlin/Any| {
+        public constructor(): R|foo/bar/Z| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|arrow/inject/annotations/Provider|() public final class W : R|kotlin/Any| {
+        public constructor(): R|foo/bar/W| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    context(R|foo/bar/Persistence|, R|foo/bar/X|, R|foo/bar/Y|, R|foo/bar/Z|, R|foo/bar/W|)
+    public final class Repo : R|kotlin/Any| {
+        public constructor(x: R|kotlin/Int|): R|foo/bar/Repo| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val x: R|kotlin/Int| = R|<local>/x|
+            public get(): R|kotlin/Int|
+
+    }
+    public final fun f(): R|kotlin/Int| {
+        R|kotlin/io/println|(String(123))
+        R|arrow/inject/annotations/context|<R|foo/bar/Persistence|, R|foo/bar/X|, R|foo/bar/Y|, R|foo/bar/Z|, R|foo/bar/W|>()
+        ^f R|foo/bar/Repo.Repo|(Int(0)).R|foo/bar/Repo.x|
+    }
+    public final fun f2(): R|kotlin/Int| {
+        R|kotlin/io/println|(String(will drop from nested body))
+        ^f2 R|arrow/inject/annotations/contextual|<R|foo/bar/Persistence|, R|kotlin/Int|>(R|foo/bar/Persistence.Persistence|(), <L> = contextual@fun R|foo/bar/Persistence|.<anonymous>(): R|kotlin/Int| <inline=Inline, kind=UNKNOWN>  {
+            ^ Int(2)
+        }
+        )
+    }
+    public final fun box(): R|kotlin/String| {
+        lval result: R|kotlin/Int| = R|foo/bar/f|()
+        ^box when () {
+            ==(R|<local>/result|, Int(0)) ->  {
+                String(OK)
+            }
+            else ->  {
+                <strcat>(String(Fail: ), R|<local>/result|)
+            }
+        }
+
+    }

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.kt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.kt
@@ -1,0 +1,34 @@
+package foo.bar
+
+import arrow.inject.annotations.context
+import arrow.inject.annotations.Provider
+import arrow.inject.annotations.contextual
+
+@Provider class Persistence
+@Provider class X
+@Provider class Y
+@Provider class Z
+@Provider class W
+
+context(Persistence, X, Y, Z, W)
+class Repo(val x: Int)
+
+fun f(): Int {
+  println("123")
+  context<Persistence, X, Y, Z, W>()
+  return Repo(0).x
+}
+
+fun f2(): Int {
+  println("will drop from nested body")
+  return contextual<Persistence, Int>(Persistence()) { 2 }
+}
+
+fun box(): String {
+  val result = f()
+  return if (result == 0) {
+    "OK"
+  } else {
+    "Fail: $result"
+  }
+}

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.fir.ir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.fir.ir.txt
@@ -1,0 +1,193 @@
+FILE fqName:foo.bar fileName:/context_receivers_with_two_type_parameters.kt
+  CLASS CLASS name:Persistence modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Persistence
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.Persistence [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Persistence modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:X modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Provider
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.X
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.X [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:X modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS CLASS name:Repo modality:FINAL visibility:public superTypes:[kotlin.Any]
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.Repo
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField0 type:foo.bar.Persistence visibility:private [final]
+    FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField1 type:foo.bar.X visibility:private [final]
+    CONSTRUCTOR visibility:public <> (_context_receiver_0:foo.bar.Persistence, _context_receiver_1:foo.bar.X, x:kotlin.Int) returnType:foo.bar.Repo [primary]
+      VALUE_PARAMETER name:_context_receiver_0 index:0 type:foo.bar.Persistence
+      VALUE_PARAMETER name:_context_receiver_1 index:1 type:foo.bar.X
+      VALUE_PARAMETER name:x index:2 type:kotlin.Int
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField0 type:foo.bar.Persistence visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_0: foo.bar.Persistence declared in foo.bar.Repo.<init>' type=foo.bar.Persistence origin=null
+        SET_FIELD 'FIELD FIELD_FOR_CLASS_CONTEXT_RECEIVER name:contextReceiverField1 type:foo.bar.X visibility:private [final]' type=kotlin.Unit origin=null
+          receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+          value: GET_VAR '_context_receiver_1: foo.bar.X declared in foo.bar.Repo.<init>' type=foo.bar.X origin=null
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Repo modality:FINAL visibility:public superTypes:[kotlin.Any]'
+    PROPERTY name:x visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          GET_VAR 'x: kotlin.Int declared in foo.bar.Repo.<init>' type=kotlin.Int origin=INITIALIZE_PROPERTY_FROM_PARAMETER
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-x> visibility:public modality:FINAL <> ($this:foo.bar.Repo) returnType:kotlin.Int
+        correspondingProperty: PROPERTY name:x visibility:public modality:FINAL [val]
+        $this: VALUE_PARAMETER name:<this> type:foo.bar.Repo
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-x> (): kotlin.Int declared in foo.bar.Repo'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: foo.bar.Repo declared in foo.bar.Repo.<get-x>' type=foo.bar.Repo origin=null
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [operator] declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  FUN name:f visibility:public modality:FINAL <> () returnType:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
+        message: CONST String type=kotlin.String value="123"
+      RETURN type=kotlin.Nothing from='public final fun f (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f'
+                  CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+                    <T>: foo.bar.X
+                    <R>: kotlin.Int
+                    ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.X' type=foo.bar.X origin=null
+                    f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.X, kotlin.Int> origin=LAMBDA
+                      FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.X) returnType:kotlin.Int
+                        $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.X
+                        BLOCK_BODY
+                          RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f.<anonymous>'
+                            CALL 'public final fun <get-x> (): kotlin.Int declared in foo.bar.Repo' type=kotlin.Int origin=GET_PROPERTY
+                              $this: CONSTRUCTOR_CALL 'public constructor <init> (_context_receiver_0: foo.bar.Persistence, _context_receiver_1: foo.bar.X, x: kotlin.Int) [primary] declared in foo.bar.Repo' type=foo.bar.Repo origin=null
+                                _context_receiver_0: GET_VAR '$this$contextual: foo.bar.Persistence declared in foo.bar.f.<anonymous>' type=foo.bar.Persistence origin=null
+                                _context_receiver_1: GET_VAR '$this$contextual: foo.bar.X declared in foo.bar.f.<anonymous>.<anonymous>' type=foo.bar.X origin=null
+                                x: CONST Int type=kotlin.Int value=0
+  FUN name:f2 visibility:public modality:FINAL <> () returnType:kotlin.Int
+    BLOCK_BODY
+      CALL 'public final fun println (message: kotlin.Any?): kotlin.Unit [inline] declared in kotlin.io.ConsoleKt' type=kotlin.Unit origin=null
+        message: CONST String type=kotlin.String value="will drop from nested body"
+      RETURN type=kotlin.Nothing from='public final fun f2 (): kotlin.Int declared in foo.bar'
+        CALL 'public final fun contextual <T, R> (ev: T of arrow.inject.annotations.RunKt.contextual, f: @[ExtensionFunctionType] kotlin.Function1<T of arrow.inject.annotations.RunKt.contextual, R of arrow.inject.annotations.RunKt.contextual>): R of arrow.inject.annotations.RunKt.contextual [inline] declared in arrow.inject.annotations.RunKt' type=kotlin.Int origin=null
+          <T>: foo.bar.Persistence
+          <R>: kotlin.Int
+          ev: CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in foo.bar.Persistence' type=foo.bar.Persistence origin=null
+          f: FUN_EXPR type=@[ExtensionFunctionType] kotlin.Function1<foo.bar.Persistence, kotlin.Int> origin=LAMBDA
+            FUN LOCAL_FUNCTION_FOR_LAMBDA name:<anonymous> visibility:local modality:FINAL <> ($receiver:foo.bar.Persistence) returnType:kotlin.Int
+              $receiver: VALUE_PARAMETER name:$this$contextual type:foo.bar.Persistence
+              BLOCK_BODY
+                RETURN type=kotlin.Nothing from='local final fun <anonymous> (): kotlin.Int declared in foo.bar.f2'
+                  CONST Int type=kotlin.Int value=2
+  FUN name:box visibility:public modality:FINAL <> () returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:result type:kotlin.Int [val]
+        CALL 'public final fun f (): kotlin.Int declared in foo.bar' type=kotlin.Int origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in foo.bar'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              arg0: GET_VAR 'val result: kotlin.Int [val] declared in foo.bar.box' type=kotlin.Int origin=null
+              arg1: CONST Int type=kotlin.Int value=0
+            then: CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: STRING_CONCATENATION type=kotlin.String
+              CONST String type=kotlin.String value="Fail: "
+              GET_VAR 'val result: kotlin.Int [val] declared in foo.bar.box' type=kotlin.Int origin=null
+FILE fqName:foo.bar.annotations fileName:/Annotations.kt
+  CLASS ANNOTATION_CLASS name:Given modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+    annotations:
+      Context
+      Retention(value = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RUNTIME' type=kotlin.annotation.AnnotationRetention)
+      Target(allowedTargets = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:CLASS' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FUNCTION' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:PROPERTY' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:VALUE_PARAMETER' type=kotlin.annotation.AnnotationTarget])
+      MustBeDocumented
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.annotations.Given
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.annotations.Given [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:Given modality:OPEN visibility:public superTypes:[kotlin.Annotation]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+  CLASS ANNOTATION_CLASS name:Config modality:OPEN visibility:public superTypes:[kotlin.Annotation]
+    annotations:
+      Context
+      Retention(value = GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:RUNTIME' type=kotlin.annotation.AnnotationRetention)
+      Target(allowedTargets = [GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:CLASS' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:FUNCTION' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:PROPERTY' type=kotlin.annotation.AnnotationTarget, GET_ENUM 'ENUM_ENTRY IR_EXTERNAL_DECLARATION_STUB name:VALUE_PARAMETER' type=kotlin.annotation.AnnotationTarget])
+      MustBeDocumented
+    $this: VALUE_PARAMETER INSTANCE_RECEIVER name:<this> type:foo.bar.annotations.Config
+    CONSTRUCTOR visibility:public <> () returnType:foo.bar.annotations.Config [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () [primary] declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS ANNOTATION_CLASS name:Config modality:OPEN visibility:public superTypes:[kotlin.Annotation]'
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN <> ($this:kotlin.Any, other:kotlin.Any?) returnType:kotlin.Boolean [fake_override,operator]
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean [fake_override,operator] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+      VALUE_PARAMETER name:other index:0 type:kotlin.Any?
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.Int [fake_override]
+      overridden:
+        public open fun hashCode (): kotlin.Int [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN <> ($this:kotlin.Any) returnType:kotlin.String [fake_override]
+      overridden:
+        public open fun toString (): kotlin.String [fake_override] declared in kotlin.Annotation
+      $this: VALUE_PARAMETER name:<this> type:kotlin.Any
+FILE fqName:foo.bar.identity fileName:/Identity.kt

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.fir.txt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.fir.txt
@@ -1,0 +1,49 @@
+FILE: context_receivers_with_two_type_parameters.kt
+    package foo.bar
+
+    @R|arrow/inject/annotations/Provider|() public final class Persistence : R|kotlin/Any| {
+        public constructor(): R|foo/bar/Persistence| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    @R|arrow/inject/annotations/Provider|() public final class X : R|kotlin/Any| {
+        public constructor(): R|foo/bar/X| {
+            super<R|kotlin/Any|>()
+        }
+
+    }
+    context(R|foo/bar/Persistence|, R|foo/bar/X|)
+    public final class Repo : R|kotlin/Any| {
+        public constructor(x: R|kotlin/Int|): R|foo/bar/Repo| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val x: R|kotlin/Int| = R|<local>/x|
+            public get(): R|kotlin/Int|
+
+    }
+    public final fun f(): R|kotlin/Int| {
+        R|kotlin/io/println|(String(123))
+        R|arrow/inject/annotations/context|<R|foo/bar/Persistence|, R|foo/bar/X|>()
+        ^f R|foo/bar/Repo.Repo|(Int(0)).R|foo/bar/Repo.x|
+    }
+    public final fun f2(): R|kotlin/Int| {
+        R|kotlin/io/println|(String(will drop from nested body))
+        ^f2 R|arrow/inject/annotations/contextual|<R|foo/bar/Persistence|, R|kotlin/Int|>(R|foo/bar/Persistence.Persistence|(), <L> = contextual@fun R|foo/bar/Persistence|.<anonymous>(): R|kotlin/Int| <inline=Inline, kind=UNKNOWN>  {
+            ^ Int(2)
+        }
+        )
+    }
+    public final fun box(): R|kotlin/String| {
+        lval result: R|kotlin/Int| = R|foo/bar/f|()
+        ^box when () {
+            ==(R|<local>/result|, Int(0)) ->  {
+                String(OK)
+            }
+            else ->  {
+                <strcat>(String(Fail: ), R|<local>/result|)
+            }
+        }
+
+    }

--- a/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.kt
+++ b/arrow-inject-compiler-plugin/src/testData/box/context-receivers/context_receivers_with_two_type_parameters.kt
@@ -1,0 +1,31 @@
+package foo.bar
+
+import arrow.inject.annotations.context
+import arrow.inject.annotations.Provider
+import arrow.inject.annotations.contextual
+
+@Provider class Persistence
+@Provider class X
+
+context(Persistence, X)
+class Repo(val x: Int)
+
+fun f(): Int {
+  println("123")
+  context<Persistence, X>()
+  return Repo(0).x
+}
+
+fun f2(): Int {
+  println("will drop from nested body")
+  return contextual<Persistence, Int>(Persistence()) { 2 }
+}
+
+fun box(): String {
+  val result = f()
+  return if (result == 0) {
+    "OK"
+  } else {
+    "Fail: $result"
+  }
+}

--- a/arrow-inject-compiler-plugin/src/testGenerated/arrow/inject/compiler/plugin/runners/BoxTestGenerated.java
+++ b/arrow-inject-compiler-plugin/src/testGenerated/arrow/inject/compiler/plugin/runners/BoxTestGenerated.java
@@ -189,5 +189,11 @@ public class BoxTestGenerated extends AbstractBoxTest {
         public void testContext_receivers_2() throws Exception {
             runTest("src/testData/box/context-receivers/context_receivers_2.kt");
         }
+
+        @Test
+        @TestMetadata("context_receivers_with_two_type_parameters.kt")
+        public void testContext_receivers_with_two_type_parameters() throws Exception {
+            runTest("src/testData/box/context-receivers/context_receivers_with_two_type_parameters.kt");
+        }
     }
 }

--- a/arrow-inject-compiler-plugin/src/testGenerated/arrow/inject/compiler/plugin/runners/BoxTestGenerated.java
+++ b/arrow-inject-compiler-plugin/src/testGenerated/arrow/inject/compiler/plugin/runners/BoxTestGenerated.java
@@ -191,6 +191,12 @@ public class BoxTestGenerated extends AbstractBoxTest {
         }
 
         @Test
+        @TestMetadata("context_receivers_with_more_than_two_type_parameters.kt")
+        public void testContext_receivers_with_more_than_two_type_parameters() throws Exception {
+            runTest("src/testData/box/context-receivers/context_receivers_with_more_than_two_type_parameters.kt");
+        }
+
+        @Test
         @TestMetadata("context_receivers_with_two_type_parameters.kt")
         public void testContext_receivers_with_two_type_parameters() throws Exception {
             runTest("src/testData/box/context-receivers/context_receivers_with_two_type_parameters.kt");


### PR DESCRIPTION
# What
This PR brings a proposal of a new implementation for `context` function. Instead a single type parameter, this proposal add a finite number of type parameters to `context` function.

# Examples
In current implementation to have multiple context injection we should do:

```kotlin
fun main() {
  context<String>()
  context<Int>()
  context<Double>()
  foo()
}
```

the idea here is to define all type injections in a single function:

```kotlin
fun main() {
  context<String, Int, Double>()
  foo()
}
```